### PR TITLE
Fix coe-intranet rewrite rules

### DIFF
--- a/rules/rules.json
+++ b/rules/rules.json
@@ -50,7 +50,7 @@
     "^/(.*) https://tamuengr.emscloudservice.com/ [H=^coe-ems-web01.engr.tamu.edu$,R=301,L]",
 
 
-    "^/(.*) https://tees.tamu.edu/employee-resources.html [H=^coe-intranet.engr.tamu.edu$,^coe-intranet.tamu.edu$,^eng-intranet.tamu.edu$,R=301,L]",
+    "^/(.*) https://tees.tamu.edu/employee-resources.html [H=^coe-intranet.engr.tamu.edu$|^coe-intranet.tamu.edu$|^eng-intranet.tamu.edu$,R=301,L]",
 
 
     "^/(.*) https://coe-connect.engr.tamu.edu [H=^coexen.engr.tamu.edu$,R=301,L]",


### PR DESCRIPTION
Fix issue with comma as the hostname separator instead of the pipe character